### PR TITLE
Add user badges in the discussion

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -103,6 +103,7 @@ $extend = [
 
     (new Extend\Settings)
         ->serializeToForum('showBadgesOnUserCard', 'v17development-user-badges.show_badges_on_user_card', 'boolval')
+        ->serializeToForum('showBadgesInDiscussion', 'v17development-user-badges.show_badges_in_discussion', 'boolval')
         ->serializeToForum('numberOfBadgesOnUserCard', 'v17development-user-badges.number_of_badges_on_user_card', 'intval')
         ->default('v17development-user-badges.number_of_badges_on_user_card', 5),
 ];

--- a/js/src/admin/components/SettingsPage.js
+++ b/js/src/admin/components/SettingsPage.js
@@ -166,6 +166,11 @@ export default class SettingsPage extends ExtensionPage {
             label: app.translator.trans('v17development-flarum-badges.admin.show_badges_on_user_card'),
           })}
           {this.buildSettingComponent({
+            type: 'switch',
+            setting: 'v17development-user-badges.show_badges_in_discussion',
+            label: app.translator.trans('v17development-flarum-badges.admin.show_badges_in_discussion'),
+          })}
+          {this.buildSettingComponent({
             type: 'number',
             setting: 'v17development-user-badges.number_of_badges_on_user_card',
             label: app.translator.trans('v17development-flarum-badges.admin.number_of_badges_on_user_card'),

--- a/js/src/forum/addDiscussionUserBadge.js
+++ b/js/src/forum/addDiscussionUserBadge.js
@@ -7,12 +7,14 @@ export default function addDiscussionUserBadge() {
   extend(CommentPost.prototype, 'content', function(list){
     const userID = this.attrs.post.data.relationships.user.data.id;
     const user = this.attrs.post.store.data.users[userID];
-
+    
     if (!app.forum.attribute('showBadgesInDiscussion') || !user.userBadges) return;
 
     const userBadges = user.userBadges() ?? [];
-    const limit = app.forum.attribute('numberOfBadgesOnUserCard');
     
+    if (userBadges.length < 1 || !userBadges) return;
+    
+    const limit = app.forum.attribute('numberOfBadgesOnUserCard');
     let visibleBadges = userBadges.filter((userBadge) => {
       return userBadge.inUserCard();
     });

--- a/js/src/forum/addDiscussionUserBadge.js
+++ b/js/src/forum/addDiscussionUserBadge.js
@@ -1,0 +1,45 @@
+import { extend } from 'flarum/extend';
+import CommentPost from 'flarum/common/components/CommentPost';
+import BadgeModal from './components/BadgeModal';
+import UserBadge from '../common/components/UserBadge';
+
+export default function addDiscussionUserBadge() {
+  extend(CommentPost.prototype, 'content', function(list){
+    const userID = this.attrs.post.data.relationships.user.data.id;
+    const user = this.attrs.post.store.data.users[userID];
+
+    if (!app.forum.attribute('showBadgesInDiscussion') || !user.userBadges) return;
+
+    const userBadges = user.userBadges() ?? [];
+    const limit = app.forum.attribute('numberOfBadgesOnUserCard');
+    
+    let visibleBadges = userBadges.filter((userBadge) => {
+      return userBadge.inUserCard();
+    });
+
+    if (visibleBadges.length === 0) {
+      visibleBadges = userBadges.slice(0, limit);
+    }
+
+    const badges = visibleBadges.map((userBadge) => {
+      return (
+        <UserBadge
+          badge={userBadge.badge()}
+          onclick={() =>
+            app.modal.show(BadgeModal, {
+              badge: userBadge.badge(),
+              userBadgeData: userBadge,
+            })
+          }
+        />
+      );
+    });
+
+    if(badges.length>0){
+      list[0].children.push(<div style="height:15px"></div>);
+      for(let i=0;i<badges.length;i++){
+        list[0].children.push(badges[i]);
+      }
+    }
+  });
+}

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -17,6 +17,7 @@ import UserBadgeListState from './states/UserBadgeListState';
 import BadgeReceivedNotification from './notification/BadgeReceivedNotification';
 import NotificationGrid from 'flarum/forum/components/NotificationGrid';
 import addBadgeListUserCard from './addBadgeListUserCard';
+import addDiscussionUserBadge from './addDiscussionUserBadge';
 import DiscussionListState from 'flarum/forum/states/DiscussionListState';
 
 app.initializers.add('v17development-flarum-badges', (app) => {
@@ -53,6 +54,7 @@ app.initializers.add('v17development-flarum-badges', (app) => {
   };
 
   addSidebarNav();
+  addDiscussionUserBadge();
 
   app.userBadgeListState = new UserBadgeListState({});
 

--- a/locale/en.yaml
+++ b/locale/en.yaml
@@ -8,8 +8,9 @@ v17development-flarum-badges:
     edit_category: Edit category
     nothing_here_yet: You did not create any badges or categories yet.
     show_badges_on_user_card: Show badges on user card
+    show_badges_in_discussion: Show badges in discussion
     number_of_badges_on_user_card: Number of badges
-    number_of_badges_on_user_card_help: Number of badges to show on user card
+    number_of_badges_on_user_card_help: Number of badges to show on user card and in discussion
 
     permissions:
       badge_detail_users: Can see users on badge details page


### PR DESCRIPTION
Desktop view:
![1664728333595](https://user-images.githubusercontent.com/29644610/193465314-67a5e14d-22a5-47af-91f0-f74d1cbc8bb8.jpg)

Mobile view:
![1664728280222](https://user-images.githubusercontent.com/29644610/193465326-2ebde469-d9ca-43af-92bc-a02cdc2f817a.jpg)

Extension setting:
The number of badges in discussion is using the "Number of badges" option
![1664667776201](https://user-images.githubusercontent.com/29644610/193465340-8ba3f0f9-4572-487c-af1a-d37814328a97.jpg)


