### PR TITLE
fix(routing): use slug for routing on UserPage

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -75,7 +75,7 @@ app.initializers.add('v17development-flarum-badges', (app) => {
       LinkButton.component(
         {
           href: app.route('user.badges', {
-            username: this.user.username(),
+            username: this.user.slug(),
           }),
           name: 'badges',
           icon: 'fas fa-user-tag',


### PR DESCRIPTION
Summary:
- Use slug instead of username for better compatibility when the slug driver is set to id or default