### PR TITLE
Fix Notification issues

### DIFF
--- a/js/src/forum/notification/BadgeReceivedNotification.js
+++ b/js/src/forum/notification/BadgeReceivedNotification.js
@@ -20,9 +20,9 @@ export default class BadgeReceivedNotification extends Notification {
 
     return (
       <div>
-        <i className={`icon ${subject.badge().icon()}`} />
+        <i className={`icon ${subject.data.attributes.icon}`} />
 
-        {subject.badge().name()}
+        {subject.data.attributes.name}
       </div>
     );
   }

--- a/src/Api/Serializer/UserBadgeSerializer.php
+++ b/src/Api/Serializer/UserBadgeSerializer.php
@@ -22,6 +22,8 @@ class UserBadgeSerializer extends AbstractSerializer
             'isPrimary'     => $userBadge->is_primary,
             'assignedAt'     => $this->formatDate($userBadge->assigned_at),
             'inUserCard'     => $userBadge->in_user_card === 1,
+            'icon' 		 => $userBadge->badge->icon,
+            'name' 		 => $userBadge->badge->name,
         ];
     }
 


### PR DESCRIPTION
Notifications are broken if the badges list isn't loaded when notification are retrieved, with this patch, we load the main info (name and icon) directly in the notifications attributes for the badge to access it directly without dependance on external data.